### PR TITLE
Ensure spiral deposition arc includes starting column

### DIFF
--- a/quick_spiral_deposition_gif_v5.py
+++ b/quick_spiral_deposition_gif_v5.py
@@ -157,9 +157,14 @@ def main():
         dphi = grid.dphi
         # which indices are crossed? take integer cells whose [i*dphi,(i+1)*dphi) intersect (ang0,ang1]
         i0 = int(math.floor(ang0 / dphi))
-        i1 = int(math.floor(ang1 / dphi))
+        # subtract a tiny epsilon so that an arc ending exactly on a boundary
+        # still activates the last touched column, while ensuring at least i0
+        # is included.
+        i1 = int(math.floor((ang1 - 1e-12) / dphi))
+        if i1 < i0:
+            i1 = i0
         added = 0
-        for i in range(i0+1, i1+1):
+        for i in range(i0, i1 + 1):
             iphi = i % grid.nphi
             if not active[0, iphi, iz]:
                 active[:, iphi, iz] = True


### PR DESCRIPTION
## Summary
- update the deposition arc activation to include the starting column while respecting wrap-around
- retain the active-column guard so previously filled cells are skipped

## Testing
- python quick_spiral_deposition_gif_v5.py --R_out 0.02 --wall_thickness 0.005 --height 0.04 --z_back 0.01 --nr 6 --nphi 12 --dz 0.005 --rho 7800 --cp 500 --k 40 --h_side 100 --h_end 100 --T_inf 20 --Ts 1500 --t_tot 1.0 --dt_fixed 0.05 --nframes 5 --pitch 0.005 --loops_per_layer 1 --layer_cells_z 1 --z0 0 --view surface --fps 5 --gif_path /workspace/ADI_thermal_fields/test.gif --quiet *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68d6a5439ed0832c875761ca06eaa7a3